### PR TITLE
Handle vercel ignored build step

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     { "src": "/api/(.*)", "dest": "/api/[...path]" },
     { "src": "/(.*)", "dest": "/dist/spa/index.html" }
   ],
-  "ignoreCommand": "pnpm install --prefer-offline --frozen-lockfile",
+  "buildCommand": "pnpm run build",
   "env": {
     "NODE_ENV": "production"
   }


### PR DESCRIPTION
Remove Vercel `ignoreCommand` and add `buildCommand` to enable successful deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-f056545a-2ffd-48f1-b816-fc3247e229a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f056545a-2ffd-48f1-b816-fc3247e229a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

