### PR TITLE
Debug blank white page on vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,11 @@
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/[...path]" },
+    { "handle": "filesystem" },
+    { "src": "/assets/(.*)", "dest": "/dist/spa/assets/$1" },
+    { "src": "/favicon.ico", "dest": "/dist/spa/favicon.ico" },
+    { "src": "/robots.txt", "dest": "/dist/spa/robots.txt" },
+    { "src": "/placeholder.svg", "dest": "/dist/spa/placeholder.svg" },
     { "src": "/(.*)", "dest": "/dist/spa/index.html" }
   ],
   "buildCommand": "pnpm run build",


### PR DESCRIPTION
Correct Vercel routing to serve static assets and fix blank page deployments.

The previous `vercel.json` configuration incorrectly routed all requests to `dist/spa/index.html`, causing built assets (like JS bundles in `/assets/`) to 404, resulting in a blank page. This change adds explicit routes for common static files and a filesystem handler to ensure these assets are served correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c1563c9-0c9f-4d34-9294-309a49078f5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c1563c9-0c9f-4d34-9294-309a49078f5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

